### PR TITLE
Change mspName to mspOfferName

### DIFF
--- a/Azure-Delegated-Resource-Management/templates/delegated-resource-management/delegatedResourceManagement.json
+++ b/Azure-Delegated-Resource-Management/templates/delegated-resource-management/delegatedResourceManagement.json
@@ -2,10 +2,10 @@
     "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "mspName": {
+        "mspOfferName": {
             "type": "string",
             "metadata": {
-                "description": "Specify the Managed Service Provider name"
+                "description": "Specify the name of the offer from the Managed Service Provider"
             }
         },
         "mspOfferDescription": {
@@ -28,7 +28,7 @@
         }              
     },
     "variables": {
-        "mspRegistrationName": "[guid(parameters('mspName'))]",
+        "mspRegistrationName": "[guid(parameters('mspOfferName'))]",
         "mspAssignmentName": "[guid(parameters('mspName'))]"
     },
     "resources": [
@@ -37,7 +37,7 @@
             "apiVersion": "2019-06-01",
             "name": "[variables('mspRegistrationName')]",
             "properties": {
-                "registrationDefinitionName": "[parameters('mspName')]",
+                "registrationDefinitionName": "[parameters('mspOfferName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]"
@@ -56,9 +56,9 @@
         }
     ],
     "outputs": {
-        "mspName": {
+        "mspOfferName": {
             "type": "string",
-            "value": "[concat('Managed by', ' ', parameters('mspName'))]"
+            "value": "[concat('Managed by', ' ', parameters('mspOfferName'))]"
         },
         "authorizations": {
             "type": "array",

--- a/Azure-Delegated-Resource-Management/templates/delegated-resource-management/delegatedResourceManagement.parameters.json
+++ b/Azure-Delegated-Resource-Management/templates/delegated-resource-management/delegatedResourceManagement.parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "mspName": {
+        "mspOfferName": {
             "value": "Fabrikam Managed Services - Interstellar"
         },
         "mspOfferDescription": {

--- a/Azure-Delegated-Resource-Management/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.json
+++ b/Azure-Delegated-Resource-Management/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.json
@@ -2,10 +2,10 @@
     "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "mspName": {
+        "mspOfferName": {
             "type": "string",
             "metadata": {
-                "description": "Specify the Managed Service Provider name"
+                "description": "Specify the name of the Offer from the Managed Service Provider"
             }
         },
         "mspOfferDescription": {
@@ -31,7 +31,7 @@
         }              
     },
     "variables": {
-        "mspRegistrationName": "[guid(parameters('mspName'))]"
+        "mspRegistrationName": "[guid(parameters('mspOfferName'))]"
     },
     "resources": [
         {
@@ -39,7 +39,7 @@
             "apiVersion": "2019-06-01",
             "name": "[variables('mspRegistrationName')]",
             "properties": {
-                "registrationDefinitionName": "[parameters('mspName')]",
+                "registrationDefinitionName": "[parameters('mspOfferName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]"
@@ -78,9 +78,9 @@
         }
     ],
     "outputs": {
-        "mspName": {
+        "mspOfferName": {
             "type": "string",
-            "value": "[concat('Managed by', ' ', parameters('mspName'))]"
+            "value": "[concat('Managed by', ' ', parameters('mspOfferName'))]"
         },
         "authorizations": {
             "type": "array",

--- a/Azure-Delegated-Resource-Management/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.parameters.json
+++ b/Azure-Delegated-Resource-Management/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "mspName": {
+        "mspOfferName": {
             "value": "Fabrikam Managed Services - Interstellar"
         },
         "mspOfferDescription": {

--- a/Azure-Delegated-Resource-Management/templates/rg-delegated-resource-management/rgDelegatedResourceManagement.json
+++ b/Azure-Delegated-Resource-Management/templates/rg-delegated-resource-management/rgDelegatedResourceManagement.json
@@ -2,10 +2,10 @@
     "$schema": "https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "mspName": {
+        "mspOfferName": {
             "type": "string",
             "metadata": {
-                "description": "Specify the Managed Service Provider name"
+                "description": "Specify the name of the offer from the Managed Service Provider"
             }
         },
         "mspOfferDescription": {
@@ -31,7 +31,7 @@
         }              
     },
     "variables": {
-        "mspRegistrationName": "[guid(parameters('mspName'))]",
+        "mspRegistrationName": "[guid(parameters('mspOfferName'))]",
         "mspAssignmentName": "[guid(parameters('rgName'))]"
     },
     "resources": [
@@ -40,7 +40,7 @@
             "apiVersion": "2019-06-01",
             "name": "[variables('mspRegistrationName')]",
             "properties": {
-                "registrationDefinitionName": "[parameters('mspName')]",
+                "registrationDefinitionName": "[parameters('mspOfferName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]"
@@ -75,9 +75,9 @@
         }
     ],
     "outputs": {
-        "mspName": {
+        "mspOfferName": {
             "type": "string",
-            "value": "[concat('Managed by', ' ', parameters('mspName'))]"
+            "value": "[concat('Managed by', ' ', parameters('mspOfferName'))]"
         },
         "authorizations": {
             "type": "array",

--- a/Azure-Delegated-Resource-Management/templates/rg-delegated-resource-management/rgDelegatedResourceManagement.parameters.json
+++ b/Azure-Delegated-Resource-Management/templates/rg-delegated-resource-management/rgDelegatedResourceManagement.parameters.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentParameters.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "mspName": {
+        "mspOfferName": {
             "value": "Fabrikam Managed Services - Interstellar"
         },
         "rgName": {


### PR DESCRIPTION
There is some confusion that the mspName is the name of the MSP, when it is actually the unique name of the offer (registration definition). This change will hopefull help people understand that the name of each offer they create is controlled by the mspOfferName property.

Feedback is based [uservoice feedback](https://feedback.azure.com/forums/922753-azure-lighthouse/suggestions/38339287-delegate-resource-groups-in-a-delegated-subscripti)