### PR TITLE
Removed delegatedRoleDefinitionIds from outputs

### DIFF
--- a/templates/delegated-resource-management/delegatedResourceManagement.json
+++ b/templates/delegated-resource-management/delegatedResourceManagement.json
@@ -78,11 +78,7 @@
         },
         "authorizations": {
             "type": "array",
-            "value": "[parameters('authorizations')]",
-             "delegatedRoleDefinitionIds": [
-                        "b24988ac-6180-42a0-ab88-20f7382dd24c",
-                        "92aaf0da-9dab-42b6-94a3-d43ce8d16293"
-                    ]
+            "value": "[parameters('authorizations')]"
         }
         
     }


### PR DESCRIPTION
The template file must not have delegatedRoleDefinitionIds, and is removed in this change. Existence of the field in the main template instead of the parameter file throws template validation error.