### PR TITLE
Changing Name of Assignment

### DIFF
--- a/templates/rg-delegated-resource-management/rgDelegatedResourceManagement.json
+++ b/templates/rg-delegated-resource-management/rgDelegatedResourceManagement.json
@@ -79,7 +79,7 @@
                         {
                             "type": "Microsoft.ManagedServices/registrationAssignments",
                             "apiVersion": "2019-06-01",
-                            "name": "[variables('mspAssignmentName')]",
+                            "name": "[guid(resourceId('Microsoft.Resources/ResourceGroups', parameters('rgName')), parameters('mspOfferName'))]",
                             "properties": {
                                 "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
                             }


### PR DESCRIPTION
The name of the RegistrationAssignment needs to be unique within the scope of it (subscription or resourcegroup). Of course this is only relevant if you want to grant multiple tenants permissions to your tenants resources. In my case it was required to allow multiple B2C directories to write their logs into the same Log Analytics Workspace. This is described here:
https://docs.microsoft.com/en-us/azure/active-directory-b2c/azure-monitor