### PR TITLE
Change variable mspAssignmentName

### DIFF
--- a/templates/rg-delegated-resource-management/rgDelegatedResourceManagement.json
+++ b/templates/rg-delegated-resource-management/rgDelegatedResourceManagement.json
@@ -47,7 +47,7 @@
     },
     "variables": {
         "mspRegistrationName": "[guid(parameters('mspOfferName'))]",
-        "mspAssignmentName": "[guid(parameters('rgName'))]"
+        "mspAssignmentName": "[guid(parameters('mspOfferName'))]"
     },
     "resources": [
         {


### PR DESCRIPTION
Creating a guid based on the RG gives conflicts if you want to create multiple delegations to the same RG (for different service providers for example). I changed it to create a guid based on the mspOfferName (like we do for the subscription delegations), this way there is not conflict as long as you have different mspoffernames.