### PR TITLE
Clarify create-keyvault-secret sample

### DIFF
--- a/templates/create-keyvault-secret/README.md
+++ b/templates/create-keyvault-secret/README.md
@@ -1,9 +1,11 @@
-# Create a Key Vault that grants MSI access to secrets
+# Create a Key Vault that grants Managed Identity access to secrets
 
-Often times a provider in Azure Lighthouse would need to store keys or secrets in Azure Key Vault so that their applications can access them securely with [Managed Service Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) (MSI).  This can be done in the provider's context without logging into the customer's tenant.
+Often times a provider in Azure Lighthouse would need to store keys or secrets in Azure Key Vault so that their applications can access them securely with [Managed Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview) (MI). This can be done in the provider's context without logging into the customer's tenant.
 
 This example demonstrates:
-1. how to [create a Key Vault in the customer's tenant](createKeyVaultSecret.json#L47). Note that you need to [specify the customer's tenant ID](createKeyVaultSecret.json#L55) during Key Vault creation, otherwise, the Key Vault is created in the provider's tenant by default. 
-2. how to [create an access policy for a principal](createKeyVaultSecret.json#L58) in the provider's tenant so that the provider can create secrets. 
-3. how to [create an access policy for the MSI of a web app](createKeyVaultSecret.json#L65) in the customer's tenant so that the web app can read the secrets.
-4. how to [put a secret in the Key Vault](createKeyVaultSecret.json#L83) created above.
+
+1. How to [create a Key Vault in the customer's tenant](createKeyVaultSecret.json#L41). Note that you need to [specify the customer's tenant ID](createKeyVaultSecret.json#L49) during Key Vault creation, otherwise, the Key Vault is created in the provider's tenant by default.
+2. How to [create an access policy for the managed identity of a web app](createKeyVaultSecret.json#L52) in the customer's tenant so that the web app can read the secrets.
+3. How to [set secret in the Key Vault](createKeyVaultSecret.json#L70) created above using [Microsoft.KeyVault/vaults/secrets](https://docs.microsoft.com/en-us/azure/templates/microsoft.keyvault/vaults/secrets#microsoftkeyvaultvaultssecrets-object) **write** action which provider's identity can perform via ARM if it has "Contributor" or "Key Vault Contributor" role on the Azure Key Vault resource.
+
+> Note: Using the ARM control-plane approach above, the provider can set/write secrets into customer's Azure Key Vault but cannot list/read these secrets using the provider's context since provider's identity is not in the customer's tenant. On the other hand, the web app will be able to read the secrets since its managed identity is in the customer's tenant and that managed identity is provided data-plane access via Key Vault [accessPolicies](createKeyVaultSecret.json#L51).

--- a/templates/create-keyvault-secret/createKeyVaultSecret.json
+++ b/templates/create-keyvault-secret/createKeyVaultSecret.json
@@ -14,12 +14,6 @@
           "description": "Specifies customer's Azure AD tenant ID where the KeyVault should be created in"
         }
       },
-      "providerPrincipalId": {
-        "type": "string",
-        "metadata": {
-          "description": "Specifies provider's user or service principal ID that should be granted KeyVault access policy"
-        }
-      },
       "webAppName": {
         "type": "string",
         "metadata": {
@@ -45,8 +39,8 @@
     "resources": [
       {
         "type": "Microsoft.KeyVault/vaults",
+        "apiVersion": "2019-09-01",
         "name": "[parameters('keyVaultName')]",
-        "apiVersion": "2018-02-14",
         "location": "[resourceGroup().location]",
         "properties": {
           "enabledForDeployment": false,
@@ -54,13 +48,6 @@
           "enabledForTemplateDeployment": false,
           "tenantId": "[parameters('customerTenantId')]",
           "accessPolicies": [
-            {
-              "objectId": "[parameters('providerPrincipalId')]",
-              "tenantId": "[parameters('customerTenantId')]",
-              "permissions": {
-                "secrets": ["list", "set"]      
-              }
-            },
             {
               "objectId": "[reference(variables('webappResourceId'), '2019-08-01', 'Full').identity.principalId]",
               "tenantId": "[parameters('customerTenantId')]",
@@ -81,8 +68,8 @@
       },
       {
         "type": "Microsoft.KeyVault/vaults/secrets",
+        "apiVersion": "2019-09-01",
         "name": "[concat(parameters('keyVaultName'), '/', parameters('secretName'))]",
-        "apiVersion": "2018-02-14",
         "location": "[resourceGroup().location]",
         "dependsOn": [
           "[resourceId('Microsoft.KeyVault/vaults', parameters('keyVaultName'))]"

--- a/templates/create-keyvault-secret/createKeyVaultSecret.parameters.json
+++ b/templates/create-keyvault-secret/createKeyVaultSecret.parameters.json
@@ -8,11 +8,8 @@
     "customerTenantId": {
       "value": "customer-aad-tenant-id"
     },
-    "providerPrincipalId": {
-      "value": "provider-user-or-principal-id"
-    },
     "webAppName": {
-      "value": "web-app-with-msi"
+      "value": "web-app-with-managed-identity"
     },
     "secretName": {
       "value": "secret-name"


### PR DESCRIPTION
Clarify create-keyvault-secret sample:
* remove access policy that was using providerPrincipalId and customerTenantId since that policy was not doing anything and secret was created via ARM and not via the data-plane APIs that accessPolicies control
* explain that provider is able to create the secret in the Key Vault through ARM control-plane but is not able to access the secrets using data-plane APIs.

/cc: @liupeirong