### PR TITLE
Fix the multiple RG template deployment JSON file

### DIFF
--- a/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.json
+++ b/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.json
@@ -6,48 +6,73 @@
             "type": "string",
             "metadata": {
                 "description": "Specify a unique name for your offer"
-            }
+            },
+            "defaultValue": "<to be filled out by MSP> Specify a title for your offer"
         },
         "mspOfferDescription": {
             "type": "string",
             "metadata": {
                 "description": "Name of the Managed Service Provider offering"
-            }
+            },
+            "defaultValue": "<to be filled out by MSP> Provide a brief description of your offer"
         },
         "managedByTenantId": {
             "type": "string",
             "metadata": {
                 "description": "Specify the tenant id of the Managed Service Provider"
-            }
+            },
+            "defaultValue": "<to be filled out by MSP> Provide your tenant id"
         },
         "authorizations": {
             "type": "array",
             "metadata": {
                 "description": "Specify an array of objects, containing tuples of Azure Active Directory principalId, a Azure roleDefinitionId, and an optional principalIdDisplayName. The roleDefinition specified is granted to the principalId in the provider's Active Directory and the principalIdDisplayName is visible to customers."
-            }
+            },
+                "defaultValue": [
+                { 
+                    "principalId": "00000000-0000-0000-0000-000000000000", 
+                    "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
+                    "principalIdDisplayName": "PIM_Group" 
+                }, 
+                { 
+                    "principalId": "00000000-0000-0000-0000-000000000000", 
+                    "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46",
+                    "principalIdDisplayName": "PIM_Group" 
+                }   
+            ]
         
         },
         "resourceGroups": {
             "type": "array",
               "metadata": { 
-                "description": "The list of resource groups to delegate. Note: resource groups must already exist in tenant" 
-            } 
+                "description": "Note: resource groups must already exist in tenant" 
+            },
+             "defaultValue": [
+                {
+                    "rgName": "test"
+                },
+                {
+                    "rgName": "test2"
+                },
+                {
+                    "rgName": "test3"
+                }
+            ] 
         }              
+    },
+    "variables": {
+        "mspRegistrationName": "[guid(parameters('mspOfferName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.ManagedServices/registrationDefinitions",
             "apiVersion": "2019-06-01",
-            "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
+            "name": "[variables('mspRegistrationName')]",
             "properties": {
                 "registrationDefinitionName": "[parameters('mspOfferName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]"
-            },
-            "copy": {
-                "name": "deploymentCopy",
-                "count": "[length(parameters('resourceGroups'))]"
             }
         },
         {
@@ -60,7 +85,7 @@
                 "count": "[length(parameters('resourceGroups'))]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
+                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
             ],
             "properties":{
                 "mode":"Incremental",
@@ -74,7 +99,7 @@
                             "apiVersion": "2019-06-01",
                             "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
                             "properties": {
-                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
+                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
                             }
                         }
                     ]

--- a/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.json
+++ b/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.json
@@ -6,73 +6,48 @@
             "type": "string",
             "metadata": {
                 "description": "Specify a unique name for your offer"
-            },
-            "defaultValue": "<to be filled out by MSP> Specify a title for your offer"
+            }
         },
         "mspOfferDescription": {
             "type": "string",
             "metadata": {
                 "description": "Name of the Managed Service Provider offering"
-            },
-            "defaultValue": "<to be filled out by MSP> Provide a brief description of your offer"
+            }
         },
         "managedByTenantId": {
             "type": "string",
             "metadata": {
                 "description": "Specify the tenant id of the Managed Service Provider"
-            },
-            "defaultValue": "<to be filled out by MSP> Provide your tenant id"
+            }
         },
         "authorizations": {
             "type": "array",
             "metadata": {
                 "description": "Specify an array of objects, containing tuples of Azure Active Directory principalId, a Azure roleDefinitionId, and an optional principalIdDisplayName. The roleDefinition specified is granted to the principalId in the provider's Active Directory and the principalIdDisplayName is visible to customers."
-            },
-                "defaultValue": [
-                { 
-                    "principalId": "00000000-0000-0000-0000-000000000000", 
-                    "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
-                    "principalIdDisplayName": "PIM_Group" 
-                }, 
-                { 
-                    "principalId": "00000000-0000-0000-0000-000000000000", 
-                    "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46",
-                    "principalIdDisplayName": "PIM_Group" 
-                }   
-            ]
+            }
         
         },
         "resourceGroups": {
             "type": "array",
               "metadata": { 
-                "description": "Note: resource groups must already exist in tenant" 
-            },
-             "defaultValue": [
-                {
-                    "rgName": "test"
-                },
-                {
-                    "rgName": "test2"
-                },
-                {
-                    "rgName": "test3"
-                }
-            ] 
+                "description": "The list of resource groups to delegate. Note: resource groups must already exist in tenant" 
+            } 
         }              
-    },
-    "variables": {
-        "mspRegistrationName": "[guid(parameters('mspOfferName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.ManagedServices/registrationDefinitions",
             "apiVersion": "2019-06-01",
-            "name": "[variables('mspRegistrationName')]",
+            "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
             "properties": {
                 "registrationDefinitionName": "[parameters('mspOfferName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]"
+            },
+            "copy": {
+                "name": "deploymentCopy",
+                "count": "[length(parameters('resourceGroups'))]"
             }
         },
         {
@@ -85,7 +60,7 @@
                 "count": "[length(parameters('resourceGroups'))]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
+                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
             ],
             "properties":{
                 "mode":"Incremental",
@@ -99,7 +74,7 @@
                             "apiVersion": "2019-06-01",
                             "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
                             "properties": {
-                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
+                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
                             }
                         }
                     ]

--- a/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.json
+++ b/templates/rg-delegated-resource-management/multipleRgDelegatedResourceManagement.json
@@ -6,74 +6,49 @@
             "type": "string",
             "metadata": {
                 "description": "Specify a unique name for your offer"
-            },
-            "defaultValue": "<to be filled out by MSP> Specify a title for your offer"
+            }
         },
         "mspOfferDescription": {
             "type": "string",
             "metadata": {
                 "description": "Name of the Managed Service Provider offering"
-            },
-            "defaultValue": "<to be filled out by MSP> Provide a brief description of your offer"
+            }
         },
         "managedByTenantId": {
             "type": "string",
             "metadata": {
                 "description": "Specify the tenant id of the Managed Service Provider"
-            },
-            "defaultValue": "<to be filled out by MSP> Provide your tenant id"
+            }
         },
         "authorizations": {
             "type": "array",
             "metadata": {
                 "description": "Specify an array of objects, containing tuples of Azure Active Directory principalId, a Azure roleDefinitionId, and an optional principalIdDisplayName. The roleDefinition specified is granted to the principalId in the provider's Active Directory and the principalIdDisplayName is visible to customers."
-            },
-                "defaultValue": [
-                { 
-                    "principalId": "00000000-0000-0000-0000-000000000000", 
-                    "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
-                    "principalIdDisplayName": "PIM_Group" 
-                }, 
-                { 
-                    "principalId": "00000000-0000-0000-0000-000000000000", 
-                    "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46",
-                    "principalIdDisplayName": "PIM_Group" 
-                }   
-            ]
+            }
         
         },
         "resourceGroups": {
             "type": "array",
               "metadata": { 
-                "description": "Note: resource groups must already exist in tenant" 
-            },
-             "defaultValue": [
-                {
-                    "rgName": "test"
-                },
-                {
-                    "rgName": "test2"
-                },
-                {
-                    "rgName": "test3"
-                }
-            ] 
+                "description": "The list of resource groups to delegate. Note: resource groups must already exist in tenant" 
+            } 
         }              
-    },
-    "variables": {
-        "mspRegistrationName": "[guid(parameters('mspOfferName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.ManagedServices/registrationDefinitions",
             "apiVersion": "2019-06-01",
-            "name": "[variables('mspRegistrationName')]",
+            "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
             "properties": {
                 "registrationDefinitionName": "[parameters('mspOfferName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]"
-            }
+            },
+            "copy": {
+                "name": "deploymentCopy",
+                "count": "[length(parameters('resourceGroups'))]"
+            },
         },
         {
             "type": "Microsoft.Resources/deployments",
@@ -85,7 +60,7 @@
                 "count": "[length(parameters('resourceGroups'))]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
+                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
             ],
             "properties":{
                 "mode":"Incremental",
@@ -99,7 +74,7 @@
                             "apiVersion": "2019-06-01",
                             "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
                             "properties": {
-                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
+                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
                             }
                         }
                     ]

--- a/templates/rg-delegatedResourceManagement-eligible-authorizations/multipleRgDelegatedResourceManagement-eligible-authorizations.json
+++ b/templates/rg-delegatedResourceManagement-eligible-authorizations/multipleRgDelegatedResourceManagement-eligible-authorizations.json
@@ -6,54 +6,91 @@
             "type": "string",
             "metadata": {
                 "description": "Specify a unique name for your offer"
-            }
+            },
+            "defaultValue": "<to be filled out by MSP> Specify a title for your offer"
         },
         "mspOfferDescription": {
             "type": "string",
             "metadata": {
                 "description": "Name of the Managed Service Provider offering"
-            }
+            },
+            "defaultValue": "<to be filled out by MSP> Provide a brief description of your offer"
         },
         "managedByTenantId": {
             "type": "string",
             "metadata": {
                 "description": "Specify the tenant id of the Managed Service Provider"
-            }
+            },
+            "defaultValue": "<to be filled out by MSP> Provide your tenant id"
         },
         "authorizations": {
             "type": "array",
             "metadata": {
                 "description": "Specify an array of objects, containing tuples of Azure Active Directory principalId, a Azure roleDefinitionId, and an optional principalIdDisplayName. The roleDefinition specified is granted to the principalId in the provider's Active Directory and the principalIdDisplayName is visible to customers."
-            }
+            },
+            "defaultValue": [
+                { 
+                    "principalId": "00000000-0000-0000-0000-000000000000", 
+                    "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
+                    "principalIdDisplayName": "PIM_Group" 
+                }, 
+                { 
+                    "principalId": "00000000-0000-0000-0000-000000000000", 
+                    "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46",
+                    "principalIdDisplayName": "PIM_Group" 
+                }   
+            ]
         },
         "eligibleAuthorizations": { 
             "type": "array", 
             "metadata": { 
                 "description": "Provide the auhtorizations that will have just-in-time role assignments on customer environments" 
-            }   
+            },
+           "defaultValue": [ 
+                { 
+                        "justInTimeAccessPolicy": { 
+                            "multiFactorAuthProvider": "Azure", 
+                            "maximumActivationDuration": "PT8H" 
+                        },
+                        "principalId": "00000000-0000-0000-0000-000000000000", 
+                        "principalIdDisplayName": "PIM_Group",
+                        "roleDefinitionId": "36243c78-bf99-498c-9df9-86d9f8d28608" 
+                        
+                }                    
+            ]    
         },   
         "resourceGroups": {
             "type": "array",
             "metadata": { 
                 "description": "Note: resource groups must already exist in tenant" 
-            }
+            },
+            "defaultValue": [
+                {
+                    "rgName": "test"
+                },
+                {
+                    "rgName": "test2"
+                },
+                {
+                    "rgName": "test3"
+                }
+            ] 
         }             
+    },
+    "variables": {
+        "mspRegistrationName": "[guid(parameters('mspOfferName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.ManagedServices/registrationDefinitions",
             "apiVersion": "2020-02-01-preview",
-            "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
+            "name": "[variables('mspRegistrationName')]",
             "properties": {
                 "registrationDefinitionName": "[parameters('mspOfferName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]",
                 "eligibleAuthorizations": "[parameters('eligibleAuthorizations')]" 
-            },
-            "copy": {
-                "name": "deploymentCopy",
-                "count": "[length(parameters('resourceGroups'))]"
             }
         },
         {
@@ -66,7 +103,7 @@
                 "count": "[length(parameters('resourceGroups'))]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
+                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
             ],
             "properties":{
                 "mode":"Incremental",
@@ -80,7 +117,7 @@
                             "apiVersion": "2020-02-01-preview",
                             "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
                             "properties": {
-                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
+                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
                             }
                         }
                     ]

--- a/templates/rg-delegatedResourceManagement-eligible-authorizations/multipleRgDelegatedResourceManagement-eligible-authorizations.json
+++ b/templates/rg-delegatedResourceManagement-eligible-authorizations/multipleRgDelegatedResourceManagement-eligible-authorizations.json
@@ -6,91 +6,54 @@
             "type": "string",
             "metadata": {
                 "description": "Specify a unique name for your offer"
-            },
-            "defaultValue": "<to be filled out by MSP> Specify a title for your offer"
+            }
         },
         "mspOfferDescription": {
             "type": "string",
             "metadata": {
                 "description": "Name of the Managed Service Provider offering"
-            },
-            "defaultValue": "<to be filled out by MSP> Provide a brief description of your offer"
+            }
         },
         "managedByTenantId": {
             "type": "string",
             "metadata": {
                 "description": "Specify the tenant id of the Managed Service Provider"
-            },
-            "defaultValue": "<to be filled out by MSP> Provide your tenant id"
+            }
         },
         "authorizations": {
             "type": "array",
             "metadata": {
                 "description": "Specify an array of objects, containing tuples of Azure Active Directory principalId, a Azure roleDefinitionId, and an optional principalIdDisplayName. The roleDefinition specified is granted to the principalId in the provider's Active Directory and the principalIdDisplayName is visible to customers."
-            },
-            "defaultValue": [
-                { 
-                    "principalId": "00000000-0000-0000-0000-000000000000", 
-                    "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7",
-                    "principalIdDisplayName": "PIM_Group" 
-                }, 
-                { 
-                    "principalId": "00000000-0000-0000-0000-000000000000", 
-                    "roleDefinitionId": "91c1777a-f3dc-4fae-b103-61d183457e46",
-                    "principalIdDisplayName": "PIM_Group" 
-                }   
-            ]
+            }
         },
         "eligibleAuthorizations": { 
             "type": "array", 
             "metadata": { 
                 "description": "Provide the auhtorizations that will have just-in-time role assignments on customer environments" 
-            },
-           "defaultValue": [ 
-                { 
-                        "justInTimeAccessPolicy": { 
-                            "multiFactorAuthProvider": "Azure", 
-                            "maximumActivationDuration": "PT8H" 
-                        },
-                        "principalId": "00000000-0000-0000-0000-000000000000", 
-                        "principalIdDisplayName": "PIM_Group",
-                        "roleDefinitionId": "36243c78-bf99-498c-9df9-86d9f8d28608" 
-                        
-                }                    
-            ]    
+            }   
         },   
         "resourceGroups": {
             "type": "array",
             "metadata": { 
                 "description": "Note: resource groups must already exist in tenant" 
-            },
-            "defaultValue": [
-                {
-                    "rgName": "test"
-                },
-                {
-                    "rgName": "test2"
-                },
-                {
-                    "rgName": "test3"
-                }
-            ] 
+            }
         }             
-    },
-    "variables": {
-        "mspRegistrationName": "[guid(parameters('mspOfferName'))]"
     },
     "resources": [
         {
             "type": "Microsoft.ManagedServices/registrationDefinitions",
             "apiVersion": "2020-02-01-preview",
-            "name": "[variables('mspRegistrationName')]",
+            "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
             "properties": {
                 "registrationDefinitionName": "[parameters('mspOfferName')]",
                 "description": "[parameters('mspOfferDescription')]",
                 "managedByTenantId": "[parameters('managedByTenantId')]",
                 "authorizations": "[parameters('authorizations')]",
                 "eligibleAuthorizations": "[parameters('eligibleAuthorizations')]" 
+            },
+            "copy": {
+                "name": "deploymentCopy",
+                "count": "[length(parameters('resourceGroups'))]"
             }
         },
         {
@@ -103,7 +66,7 @@
                 "count": "[length(parameters('resourceGroups'))]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
+                "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
             ],
             "properties":{
                 "mode":"Incremental",
@@ -117,7 +80,7 @@
                             "apiVersion": "2020-02-01-preview",
                             "name": "[guid(parameters('resourceGroups')[copyIndex()].rgName)]",
                             "properties": {
-                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('mspRegistrationName'))]"
+                                "registrationDefinitionId": "[resourceId('Microsoft.ManagedServices/registrationDefinitions/', guid(parameters('resourceGroups')[copyIndex()].rgName))]"
                             }
                         }
                     ]


### PR DESCRIPTION
As part of [this work item](https://msazure.visualstudio.com/One/_workitems/edit/10510061), we had a CRI where a customer noticed when they re-ran the multiple RG template deployment with a subset of RGs specified all RGs would still be updated. This was due to the fact that only one registration definition was created behind the scenes. We need to create N registration definitions and N registration assignments where N is the number of resource groups specified.