### PR TITLE
new policy for multiple offers in a tenant

### DIFF
--- a/templates/policy-delegate-multiple-management-groups/deployLighthouseIfNotExistManagementGroup.json
+++ b/templates/policy-delegate-multiple-management-groups/deployLighthouseIfNotExistManagementGroup.json
@@ -1,0 +1,181 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-08-01/managementGroupDeploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "managedByTenantId": {
+            "type": "string",
+            "metadata": {
+                "description": "Add the tenant id provided by the MSP"
+            }
+        },
+        "managedByName": {
+            "type": "string",
+            "metadata": {
+                "description": "Add the tenant name of the provided MSP"
+            }
+        },
+        "managedByDescription": {
+            "type": "string",
+            "metadata": {
+                "description": "Add the description of the offer provided by the MSP"
+            }
+        },
+        "managedByAuthorizations": {
+            "type": "array",
+            "metadata": {
+                "description": "Add the authZ array provided by the MSP"
+            }
+        }
+    },
+    "variables": {
+        "policyDefinitionName": "Enable-Azure-Lighthouse",
+        "rbacOwner": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Authorization/policyDefinitions",
+            "apiVersion": "2018-05-01",
+            "name": "[variables('policyDefinitionName')]",
+            "properties": {
+                "description": "Policy to enforce Lighthouse on subscriptions, delegating mgmt to MSP",
+                "displayName": "Enforce Lighthouse on subscriptions",
+                "mode": "All",
+                "policyType": "Custom",
+                "parameters": {
+                    "managedByTenantId": {
+                        "type": "string",                        
+                        "defaultValue" : "[parameters('managedByTenantId')]",
+                        "metadata": {                            
+                            "description": "Add the tenant id provided by the MSP"
+                        }
+                    },
+                    "managedByName": {
+                        "type": "string",
+                        "defaultValue" : "[parameters('managedByName')]",
+                        "metadata": {
+                            "description": "Add the tenant name of the provided MSP"
+                        }
+                    },
+                    "managedByDescription": {
+                        "type": "string",
+                        "defaultValue" : "[parameters('managedByDescription')]",
+                        "metadata": {
+                            "description": "Add the description of the offer provided by the MSP"
+                        }
+                    },
+                    "managedByAuthorizations": {
+                        "type": "array",
+                        "defaultValue" : "[parameters('managedByAuthorizations')]",
+                        "metadata": {
+                            "description": "Add the authZ array provided by the MSP"
+                        }
+                    }
+                },
+                "policyRule": {
+                    "if": {
+                        "allOf": [
+                            {
+                                "field": "type",
+                                "equals": "Microsoft.Resources/subscriptions"
+                            }
+                        ]
+                    },
+                    "then": {
+                        "effect": "deployIfNotExists",
+                        "details": {
+                            "type": "Microsoft.ManagedServices/registrationDefinitions",
+                            "deploymentScope": "Subscription",
+                            "existenceScope": "Subscription",
+                            "roleDefinitionIds": [
+                                "[concat('/providers/Microsoft.Authorization/roleDefinitions/', variables('rbacOwner'))]"
+                            ],
+                            "existenceCondition": {
+                                "allOf": [
+                                    {
+                                        "field": "type",
+                                        "equals": "Microsoft.ManagedServices/registrationDefinitions"
+                                    },
+                                    {
+                                        "field": "Microsoft.ManagedServices/registrationDefinitions/managedByTenantId",
+                                        "equals": "[[parameters('managedByTenantId')]"
+                                    },
+                                    {
+                                        "field": "Microsoft.ManagedServices/registrationDefinitions/registrationDefinitionName",
+                                        "equals": "[[parameters('managedByName')]"
+                                    }
+                                ]
+                            },
+                            "deployment": {
+                                "location": "westeurope",
+                                "properties": {
+                                    "mode": "incremental",
+                                    "parameters": {
+                                        "managedByTenantId": {
+                                            "value": "[[parameters('managedByTenantId')]"
+                                        },
+                                        "managedByName": {
+                                            "value": "[[parameters('managedByName')]"
+                                        },
+                                        "managedByDescription": {
+                                            "value": "[[parameters('managedByDescription')]"
+                                        },
+                                        "managedByAuthorizations": {
+                                            "value": "[[parameters('managedByAuthorizations')]"
+                                        }
+                                    },
+                                    "template": {
+                                        "$schema": "https://schema.management.azure.com/2018-05-01/subscriptionDeploymentTemplate.json#",
+                                        "contentVersion": "1.0.0.0",
+                                        "parameters": {
+                                            "managedByTenantId": {
+                                                "type": "string"
+                                            },
+                                            "managedByName": {
+                                                "type": "string"
+                                            },
+                                            "managedByDescription": {
+                                                "type": "string"
+                                            },
+                                            "managedByAuthorizations": {
+                                                "type": "array"
+                                            }
+                                        },
+                                        "variables": {
+                                            "managedByRegistrationName": "[[guid(parameters('managedByName'))]",
+                                            "managedByAssignmentName": "[[guid(parameters('managedByName'))]"
+                                        },
+                                        "resources": [
+                                            {
+                                                "type": "Microsoft.ManagedServices/registrationDefinitions",
+                                                "apiVersion": "2019-06-01",
+                                                "name": "[[variables('managedByRegistrationName')]",
+                                                "properties": {
+                                                    "registrationDefinitionName": "[[parameters('managedByName')]",
+                                                    "description": "[[parameters('managedByDescription')]",
+                                                    "managedByTenantId": "[[parameters('managedByTenantId')]",
+                                                    "authorizations": "[[parameters('managedByAuthorizations')]"
+                                                }
+                                            },
+                                            {
+                                                "type": "Microsoft.ManagedServices/registrationAssignments",
+                                                "apiVersion": "2019-06-01",
+                                                "name": "[[variables('managedByAssignmentName')]",
+                                                "dependsOn": [
+                                                    "[[resourceId('Microsoft.ManagedServices/registrationDefinitions/', variables('managedByRegistrationName'))]"], 
+                                                "properties": {
+                                                    "registrationDefinitionId": "[[resourceId('Microsoft.ManagedServices/registrationDefinitions/',variables('managedByRegistrationName'))]"
+                                            }
+                                            }
+                                        ]
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ],
+    "outputs": {
+    }
+}

--- a/templates/policy-delegate-multiple-management-groups/deployLighthouseIfNotExistsManagementGroup.parameters.json
+++ b/templates/policy-delegate-multiple-management-groups/deployLighthouseIfNotExistsManagementGroup.parameters.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "managedByName": {
+            "value": "Relecloud Managed Services"
+        },
+        "managedByDescription": {
+            "value": "This is the ultimate MSP"
+        },
+        "managedByTenantId": {
+            "value": "00000000-0000-0000-0000-000000000000"
+        },
+        "managedByAuthorizations": {
+            "value": [
+                {
+                    "principalId": "00000000-0000-0000-0000-000000000000",
+                    "principalIdDisplayName": "Tier 1 Support",
+                    "roleDefinitionId": "acdd72a7-3385-48ef-bd42-f606fba81ae7"
+                },
+                {
+                    "principalId": "00000000-0000-0000-0000-000000000000",
+                    "principalIdDisplayName": "Automation Account - Full access",
+                    "roleDefinitionId": "18d7d88d-d35e-4fb5-a5c3-7773c20a72d9",
+                    "delegatedRoleDefinitionIds": [
+                        "b24988ac-6180-42a0-ab88-20f7382dd24c",
+                        "92aaf0da-9dab-42b6-94a3-d43ce8d16293",
+                        "91c1777a-f3dc-4fae-b103-61d183457e46"
+                    ]
+                }                
+            ]
+        }
+    }
+}

--- a/templates/policy-delegate-multiple-management-groups/readme.md
+++ b/templates/policy-delegate-multiple-management-groups/readme.md
@@ -1,0 +1,18 @@
+# Azure Policy to create multiple, distinct delegations across a management group hierarchy
+This policy is built for customers whom wish to deploy Azure Lighthouse at scale with **multiple** distinct offers within an enterprise management group structure. Most customers should leverage the default [policy-delegate-management-groups](../policy-delegate-management-groups/readme.md) policy unless there is a specific design need for distinct offers of different configurations within the same management group hierarchy. 
+
+**Pre-requisite**: Register subscriptions within the management group for the Managed Services RP. Otherwise, the policy will not run. 
+
+To automatically register the Managed Services RP, you can use the following Logic Apps:
+- https://github.com/Azure/Azure-Lighthouse-samples/tree/master/templates/register-managed-services-rp-partner
+- https://github.com/Azure/Azure-Lighthouse-samples/tree/master/templates/register-managed-services-rp-customer
+
+This Azure Policy has a DeployIfNotExists effect, evaluating subscriptions within a management group to determine if there is an existing Azure Lighthouse delegation using **managedByName**. If not, then a deployment to the specified managing tenant is executed. When using this policy for **multiple** offers use unique policy names and **managedByName** parameters in addition to the specific delegations required.  
+
+Use the following Powershell command to deploy this policy at the management group scope:
+
+`
+New-AzManagementGroupDeployment -Name <nameofDeployment> -Location <location> -ManagementGroupId <nameOfMg> -TemplateFile <path to file> -TemplateParameterFile <path to parameter file> -verbose
+`
+
+


### PR DESCRIPTION
from a previous customer engagement, we've created an additional policy for onboarding multiple lighthouse offers at scale. specifically, our customer required policies to onboard 2 unique offers within a management group hierarchy.  this is tested & deployed in our lab & the customer environment.  @chintalavr 